### PR TITLE
Corrects MDB2 login for (at least) Debian

### DIFF
--- a/php/login.php
+++ b/php/login.php
@@ -147,7 +147,7 @@
    $languages = array(); 
    
    if ($res->numrows() > 0) {
-      while ($row = $sth->fetchrow()) {
+      while ($row = $res->fetchrow()) {
          $languages[$row["abbreviation"]] = $row["language_name"];
       }
    } 


### PR DESCRIPTION
We had a problem with a Debian Wheezy with standard PHP and MDB2, with the main page ending up blank with an error:

[02-Oct-2014 15:02:02 UTC] PHP Fatal error:  Call to undefined method MDB2_Statement_mysql::fetchrow() in /srv/www/maia/login.php on line 150

This small patch corrects it.
