### PR TITLE
Fixed db versjon in configtest.pl

### DIFF
--- a/scripts/configtest.pl
+++ b/scripts/configtest.pl
@@ -253,7 +253,7 @@
     );
 
     my @databases = (
-	   {product => "MySQL Server", minver => "10.0.16",
+	   {product => "MySQL Server", minver => "5.0.0",
 	     verquery => "SELECT VERSION()", regexp => '^(\d+\.\d+\.\d+)'},
 	
 	    {product => "PostgreSQL Server", minver => "8.4", 

--- a/scripts/configtest.pl
+++ b/scripts/configtest.pl
@@ -253,8 +253,7 @@
     );
 
     my @databases = (
-	
-	    {product => "MySQL Server", minver => "", 
+	   {product => "MySQL Server", minver => "10.0.16",
 	     verquery => "SELECT VERSION()", regexp => '^(\d+\.\d+\.\d+)'},
 	
 	    {product => "PostgreSQL Server", minver => "8.4", 
@@ -385,7 +384,7 @@
               my $dbupgrade = 0;
               if (defined($db->{minver}) && $db->{minver} ne "") {
 	             $db->{minver} = sprintf("%s", $db->{minver});
-                 $dbupgrade = $dbversion lt $db->{minver};
+                 $dbupgrade = $dbversion < $db->{minver};
               }
 
               # Do we need to warn about this version of MySQL/PostgreSQL?


### PR DESCRIPTION
The lt operator compare variables as strings, and < compare variables as numbers.
I have changed the operator from "lt" to "<".

Also updated $minversjon to 10.0.16 which is the latest mariadb version.

