### PR TITLE
Fix two errors in php files

### DIFF
--- a/php/admin/configtest.php
+++ b/php/admin/configtest.php
@@ -730,7 +730,7 @@
             $status = ERROR;
         }
     } else {
-        $result = "(OPTIONAL) purifer_cache is not set in maia_config.php.  Maia will work without it, but the " .
+        $result = "(OPTIONAL) purifer_cache is not set in config.php.  Maia will work without it, but the " .
                   "message viewer might be a little faster if you set it to a directory that is " .
                   "writable by the web server.";
         $status = WARN;

--- a/php/maia_db/user_management.php
+++ b/php/maia_db/user_management.php
@@ -262,7 +262,7 @@
 
         // Link the e-mail address to the new owner
         $sth = $dbh->prepare("UPDATE users SET maia_user_id = ? WHERE email = ?");
-        $sth->execute(array($new_owner_id, $emaila));
+        $sth->execute(array($new_owner_id, $email));
         if (PEAR::isError($sth)) {
             die($sth->getMessage());
         }


### PR DESCRIPTION
* `maia_config.php` is a non existent document, update to reference the correct file name `config.php` - fixes #34  

* fix a typo in `user_management.php` which prevented linking of new email addresses to existing accounts - fixes #32 