### PR TITLE
X-Spam-Status not showing autolearn part #35

### DIFF
--- a/maiad
+++ b/maiad
@@ -4404,6 +4404,10 @@ sub maia_record_tests($$$$$) {
     }
 
     # update the mail item's final score
+    #
+    if ($autolearn_status eq "") {
+          $autolearn_status = "unavailable";
+    }
     $update = "UPDATE maia_mail SET score = ?, autolearn_status = ? WHERE id = ?";
     $sth = $dbh->prepare_cached($update)
         or do_log(0, sprintf("Maia: [record_tests] Couldn't prepare query: %s", $dbh->errstr));
@@ -14355,7 +14359,15 @@ sub spam_scan($$$) {
         $spam_report = $per_msg_status->get_report;  # taints $1 and $2 !
 
         # 'ham', 'spam', 'no', 'disabled', 'failed', 'unavailable'
-        $autolearn_status = $per_msg_status->get_autolearn_status;
+        #$autolearn_status = $per_msg_status->get_autolearn_status;
+        #
+        my ($autolearn, $not_used) = split / /, $per_msg_status->get_autolearn_status;
+        if ( $autolearn eq "") {
+          $autolearn_status = "unavailable";
+        }
+        else {
+          $autolearn_status = $autolearn;
+        }
 
       # example of how to gather aditional information from SA:
       # my($trusted) = $per_msg_status->_get_tag('RELAYSTRUSTED');


### PR DESCRIPTION
I noticed that I had a lot of SQL errors on this table:  

```sql
CREATE TABLE maia_mail (
   id               SERIAL PRIMARY KEY,
   received_date    TIMESTAMP NOT NULL,
   size             INTEGER NOT NULL,
   sender_email     BYTEA NOT NULL,
   envelope_to      BYTEA NOT NULL,
   subject          VARCHAR(255) NOT NULL,
   contents         BYTEA NOT NULL,
   score            NUMERIC(7,3), -- only supplied for (S)pam
   autolearn_status VARCHAR(15) DEFAULT 'unavailable' NOT NULL -- 'ham', 'spam', 'no', 'disabled', 'failed', 'unavailable'
);
CREATE INDEX maia_mail_idx_received_date ON maia_mail(received_date);
CREATE INDEX maia_mail_idx_sender_email ON maia_mail(sender_email);
CREATE INDEX maia_mail_idx_subject ON maia_mail(subject);
CREATE INDEX maia_mail_idx_score ON maia_mail(score);
```

Looking deeper into the issue I see that the field autolearn_status was empty when doing an insert and it is defined as NOT NULL.   I removed the NOT NULL and ran into other issues, so I solved the issue in the maiad code.  

It is tested in my environment using Gentoo Linux, spamassassin 3.4.1, postgresql 9.4.x

How I fixed it.  To put always the default value into the autolearn_status and secondly I found out that the value returned from spamassassin included "autolearn=ham autolearn_force=no" which I split up into 2 variables to actually get the correct value. 

Kurt 

