### PR TITLE
Update smarty.php

### DIFF
--- a/php/smarty.php
+++ b/php/smarty.php
@@ -94,9 +94,9 @@
             $this->cache_dir = $this->_basedir.'cached/';
             $this->caching = false;
             if (!empty($spath)) {
-                $this->plugins_dir = array($this->_basedir.'code/', $spath . '/plugins');
+                $this->addPluginsDir(array($spath . '/plugins', $this->_basedir.'code/'));
             } else {
-                $this->plugins_dir = array($this->_basedir.'code/', "Smarty/plugins");
+                $this->addPluginsDir(array($this->_basedir.'code/'));
             }
             $this->assign('template_dir', 'themes/'.$theme.'/');
         }


### PR DESCRIPTION
Fix smarty3 errors.

Direct from smarty's website:

> As of Smarty 3.1 the attribute $plugins_dir is no longer accessible directly. Use getPluginsDir(), setPluginsDir() and addPluginsDir() instead. 