### PR TITLE
Fixed error handler but... #54

### DIFF
--- a/php/xsettings.php
+++ b/php/xsettings.php
@@ -645,9 +645,9 @@
             $address = $row["email"];
             if (isset($_POST["make_primary_" . $email_id])) {
                 $sth2 = $dbh->prepare("UPDATE maia_users SET primary_email_id = ? WHERE id = ?");
-                $sth2->execute(array($email_id, $user_id));
-                if (PEAR::isError($sth)) {
-                    die($sth->getMessage());
+                $res = $sth2->execute(array($email_id, $user_id));
+                if (PEAR::isError($res)) {
+                    die($res->getMessage());
                 }
                 $sth2->free();
                 $message = sprintf($lang['text_new_primary_email'], $address);


### PR DESCRIPTION
Fixed error handler but I found problem about primary address on settings.php

settings.php can set the primary address that is "not" included in maia_users table. Because, maia_users.primary_email_id is set in unique. 

see #54