### PR TITLE
Fix SQL errors in rescue.php

### DIFF
--- a/php/rescue.php
+++ b/php/rescue.php
@@ -124,8 +124,15 @@
                   "AND maia_mail_recipients.token = ? " .
                   "AND  SUBSTRING(maia_mail_recipients.token FROM 1 FOR 7) <> 'expired' " .
                   "AND maia_mail_recipients.recipient_id = ?";
-        $sth = $dbh->query($select, array($token, $euid));
-        while ($row = $sth->fetchRow())
+        $sth = $dbh->prepare($select);
+        if (PEAR::isError($sth)) {
+            die($sth->getMessage() . ": " . $dbh->last_query . " [" . $token . "] [" . $euid . "]");
+        }
+	$res = $sth->execute(array($token, $euid));
+        if (PEAR::isError($res)) {
+            die($res->getMessage() . ": " . $dbh->last_query . " [" . $token . "] [" . $euid . "]");
+        }
+        while ($row = $res->fetchRow())
         {
             $mail_id = $row["id"];
             $sender  = $row["sender_email"];
@@ -151,8 +158,15 @@
                   "AND maia_mail_recipients.token = ? " .
                   "AND  SUBSTRING(maia_mail_recipients.token FROM 1 FOR 7) <> 'expired' " .
                   "AND maia_mail_recipients.recipient_id = ?";
-        $sth = $dbh->query($select, array($token, $euid));
-        while ($row = $sth->fetchRow())
+        $sth = $dbh->prepare($select);
+        if (PEAR::isError($sth)) {
+            die($sth->getMessage() . ": " . $dbh->last_query . " [" . $token . "] [" . $euid . "]");
+        }
+	$res = $sth->execute(array($token, $euid));
+        if (PEAR::isError($res)) {
+            die($res->getMessage() . ": " . $dbh->last_query . " [" . $token . "] [" . $euid . "]");
+        }
+        while ($row = $res->fetchRow())
         {
             $mail_id = $row["id"];
             $sender  = $row["sender_email"];
@@ -178,8 +192,15 @@
                   "AND maia_mail_recipients.token = ? " .
                   "AND  SUBSTRING(maia_mail_recipients.token FROM 1 FOR 7) <> 'expired' " .
                   "AND maia_mail_recipients.recipient_id = ?";
-        $sth = $dbh->query($select, array($token, $euid));
-        while ($row = $sth->fetchRow())
+        $sth = $dbh->prepare($select);
+        if (PEAR::isError($sth)) {
+            die($sth->getMessage() . ": " . $dbh->last_query . " [" . $token . "] [" . $euid . "]");
+        }
+	$res = $sth->execute(array($token, $euid));
+        if (PEAR::isError($res)) {
+            die($res->getMessage() . ": " . $dbh->last_query . " [" . $token . "] [" . $euid . "]");
+        }
+        while ($row = $res->fetchRow())
         {
             $mail_id = $row["id"];
             $sender  = $row["sender_email"];
@@ -205,8 +226,15 @@
                   "AND maia_mail_recipients.token = ? " .
                   "AND  SUBSTRING(maia_mail_recipients.token FROM 1 FOR 7) <> 'expired' " .
                   "AND maia_mail_recipients.recipient_id = ?";
-        $sth = $dbh->query($select, array($token, $euid));
-        while ($row = $sth->fetchRow())
+        $sth = $dbh->prepare($select);
+        if (PEAR::isError($sth)) {
+            die($sth->getMessage() . ": " . $dbh->last_query . " [" . $token . "] [" . $euid . "]");
+        }
+	$res = $sth->execute(array($token, $euid));
+        if (PEAR::isError($res)) {
+            die($res->getMessage() . ": " . $dbh->last_query . " [" . $token . "] [" . $euid . "]");
+        }
+        while ($row = $res->fetchRow())
         {
             $mail_id = $row["id"];
             $sender  = $row["sender_email"];
@@ -231,8 +259,15 @@
                   "AND maia_mail_recipients.token = ? " .
                   "AND  SUBSTRING(maia_mail_recipients.token FROM 1 FOR 7) <> 'expired' " .
                   "AND maia_mail_recipients.recipient_id = ?";
-        $sth = $dbh->query($select, array($token, $euid));
-        while ($row = $sth->fetchRow())
+        $sth = $dbh->prepare($select);
+        if (PEAR::isError($sth)) {
+            die($sth->getMessage() . ": " . $dbh->last_query . " [" . $token . "] [" . $euid . "]");
+        }
+	$res = $sth->execute(array($token, $euid));
+        if (PEAR::isError($res)) {
+            die($res->getMessage() . ": " . $dbh->last_query . " [" . $token . "] [" . $euid . "]");
+        }
+        while ($row = $res->fetchRow())
         {
             $mail_id = $row["id"];
             $sender  = $row["sender_email"];


### PR DESCRIPTION
When using the links from the digest emails to mark a message as spam/not spam, an SQL error is triggered. This change fixes that.

There are other possible instances of the same error in other parts of the code as follows:

admin/dblib.php:            $sth = $dbh->query($select, array($index_name, $table_name));
adminviruses.php:    $smarty->assign('rows', $dbh->queryall($select));
chart_stats.php:      $sth = $dbh->query($select, $id);
maia_db/util.php:                $res =& $db->query($query, $dbparams);
rulestats.php:      $sth = $dbh->query($select,$euid);
virusstats.php:      $sth = $dbh->query($select,$euid);
xadminthemes.php:         $dbh->query($insert, array($name, $theme_path));
xadminthemes.php:                       $dbh->query($update, array($default_theme_id, $id));            
xadminthemes.php:                   $dbh->query($delete, array($id));            
xadminviruses.php:          $sth = $dbh->query($select, array($alias));
xadminviruses.php:          $sth = $dbh->query($select, array($alias_name));
xadminviruses.php:              $dbh->query($insert, array($virus, $alias_name));
xadminviruses.php:              $sth2 = $dbh->query($select, array($virus));
xadminviruses.php:              $dbh->query($update, array($virus_count + $alias_count, $virus));
xadminviruses.php:              $dbh->query($update, array($virus, $alias));
xadminviruses.php:              $dbh->query($delete, array($alias));
xadminviruses.php:              $dbh->query($delete, array($alias_name, $virus_id));
