### PR TITLE
Changed to test for mysqli instead of mysql

### DIFF
--- a/php/admin/configtest.php
+++ b/php/admin/configtest.php
@@ -431,17 +431,17 @@
     }
     print_row("PEAR::MDB2", $result, $status);
 
-    // PEAR::MDB2:mysql
+    // PEAR::MDB2:mysqli
     if ($have_pear) {
-        if (!in_array("mdb2_driver_mysql", $pear_list)) {
+        if (!in_array("mdb2_driver_mysqli", $pear_list)) {
             $result = "Not installed.  This PHP extension is required in order to provide " .
-                      "database abstraction.  Use <b>pear install MDB2#mysql</b> to install this.";
+                      "database abstraction.  Use <b>pear install MDB2#mysqli</b> to install this.";
             $status = ERROR;
         } else {
-            $result = "Pear::MDB2#mysql installed";
+            $result = "Pear::MDB2#mysqli installed";
             $status = OK;
         }
-        print_row("PEAR::MDB2#mysql", $result, $status);
+        print_row("PEAR::MDB2#mysqli", $result, $status);
     }
 
 //Database Version


### PR DESCRIPTION
In php7 mysql driver has been removed, therefore mysqli driver should be used.