### PR TITLE
Fixed some mysqli query bugs and replaced scrypt with crypt for PHP 5.6+ compatability

### DIFF
--- a/php/chart_rules.php
+++ b/php/chart_rules.php
@@ -115,7 +115,7 @@
     }
     
     // create the graph
-    $Graph =& Image_Graph::factory('graph', array(400, 300));
+    $Graph =& Image_Graph::factory('graph', array(800, 600));
     // add a TrueType font
     $Font =& $Graph->addNew('ttf_font', $chart_font);
     // set the font size to 11 pixels
@@ -147,9 +147,9 @@
 
     
     $select = "SELECT rule_name, rule_count " .
-              "FROM maia_sa_rules WHERE rule_count > 0 ORDER BY rule_count DESC, rule_name ASC LIMIT ".$out['limit'];
+              "FROM maia_sa_rules WHERE rule_count > 0 ORDER BY rule_count DESC, rule_name ASC LIMIT ?";
     $sth = $dbh->prepare($select);
-    $res = $sth->execute();
+    $res = $sth->execute($out['limit']);
     if (PEAR::isError($sth)) {
         die($sth->getMessage());
     }
@@ -158,21 +158,21 @@
     $values = array();
     if($res->numRows()) {
         $sum = 0;
-        while ($row = $sth->fetchrow()) {
+        while ($row = $res->fetchRow()) {
             $Dataset->addPoint($row["rule_name"], $row["rule_count"], $row["rule_name"]);
             $keys[] = $row["rule_name"];
             $values[] = $row["rule_count"];
             $sum += $row["rule_count"];
         }
-        $select = "SELECT (SUM(rule_count)-".$sum.") AS rest FROM maia_sa_rules";
+        $select = "SELECT (SUM(rule_count)-?) AS rest FROM maia_sa_rules";
 
         $sth = $dbh->prepare($select);
-        $res = $sth->execute();
+        $res = $sth->execute($sum);
         if (PEAR::isError($sth)) {
-            die($sth->getMessage());
+            die($res->getMessage());
         }
         if($res->numRows()) {
-            $row = $sth->fetchrow();
+            $row = $res->fetchrow();
             if(0 && $row["rest"]) {
                 $Dataset->addPoint("Rest", $row["rest"], "Rest");
                 $keys[] = "Rest";

--- a/php/chart_stats.php
+++ b/php/chart_stats.php
@@ -173,8 +173,8 @@
                      "total_spam_items as s, total_fp_items as fp, total_fn_items as fn, total_virus_items as v, total_bad_header_items as bh, total_banned_file_items as bf, " .
                      "total_oversized_items as os " .
               "FROM maia_stats " .
-              "WHERE user_id = ?";
-      $sth = $dbh->query($select, $id);
+              "WHERE user_id = $id";
+      $sth = $dbh->query($select);
     }
     $items = array();
     if($row = $sth->fetchrow()) {

--- a/php/maia_db/scrypt.php
+++ b/php/maia_db/scrypt.php
@@ -142,7 +142,8 @@ abstract class Password
             $salt = str_replace(array('+', '$'), array('.', ''), base64_encode($salt));
         }
 
-        $hash = scrypt($password, $salt, $N, $r, $p, self::$_keyLength);
+        #$hash = scrypt($password, $salt, $N, $r, $p, self::$_keyLength);
+        $hash = crypt($password, $salt);
 
         return $N . '$' . $r . '$' . $p . '$' . $salt . '$' . $hash;
     }
@@ -174,7 +175,8 @@ abstract class Password
             return false;
         }
 
-        $calculated = scrypt($password, $salt, $N, $r, $p, self::$_keyLength);
+        #$calculated = scrypt($password, $salt, $N, $r, $p, self::$_keyLength);
+        $calculated = crypt($password, $salt);
 
         // Use compareStrings to avoid timeing attacks
         return self::compareStrings($hash, $calculated);

--- a/php/rulestats.php
+++ b/php/rulestats.php
@@ -92,8 +92,8 @@
     $sth->free();
     
     if ($enable_charts) {
-      $select = "SELECT charts FROM maia_users WHERE id=?";
-      $sth = $dbh->query($select,$euid);
+      $select = "SELECT charts FROM maia_users WHERE id=$euid";
+      $sth = $dbh->query($select);
       if ($row = $sth->fetchrow()) {
         $enable_charts = ($row["charts"] == 'Y');
       }

--- a/php/virusstats.php
+++ b/php/virusstats.php
@@ -94,8 +94,8 @@
     $sth->free();
     
     if ($enable_charts) {
-      $select = "SELECT charts FROM maia_users WHERE id=?";
-      $sth = $dbh->query($select,$euid);
+      $select = "SELECT charts FROM maia_users WHERE id=$euid";
+      $sth = $dbh->query($select);
       if ($row = $sth->fetchrow()) {
         $enable_charts = ($row["charts"] == 'Y');
       }


### PR DESCRIPTION
* PHP: Increased the size of the stats graph for spam rules stats.
* PHP/Mysql: Fixed issues with prepared and non prepared MySQL statements so graphs display without a 500 error.
* PHP: replaced scrypt with crypt function to allow it to work with PHP versions that no longer support scrypt.