### PR TITLE
Fix error in processing content type header

### DIFF
--- a/maiad
+++ b/maiad
@@ -3823,7 +3823,9 @@ sub maia_store_mail($$$$$@) {
        if (validate($htype, '^Subject$', 'i')) {
           $subject .= $htext;
        }
-       if (validate($htype, '^Content-Type$', 'i') && validate($htext, 'charset=(.+)')) {
+       if (validate($htype, '^Content-Type$', 'i') && validate($htext, 'charset="(.+)"')) {
+          $document_charset = validate($htext, 'charset="(.+)"');
+       } elsif (validate($htype, '^Content-Type$', 'i') && validate($htext, 'charset=(.+)')) {
           $document_charset = validate($htext, 'charset=(.+)');
        }
     }
@@ -3832,7 +3834,7 @@ sub maia_store_mail($$$$$@) {
     $subject = untaint($subject);
     $sender = substr($sender, 0, 255) if length($sender) > 255;
     if ($document_charset ne "") {
-	from_to($contents, $document_charset, "UTF-8");
+	from_to($contents, $document_charset, 'UTF-8');
     }
 
     if (!$oversized) {

--- a/maiad
+++ b/maiad
@@ -3823,14 +3823,17 @@ sub maia_store_mail($$$$$@) {
        if (validate($htype, '^Subject$', 'i')) {
           $subject .= $htext;
        }
-       if (validate($htype, '^Content-Type$', 'i') && validate($htext, 'charset="(.+)"')) {
-          $document_charset = validate($htext, 'charset="(.+)"');
+       if (validate($htype, '^Content-Type$', 'i') && validate($htext, 'charset=(.+)')) {
+          $document_charset = validate($htext, 'charset=(.+)');
        }
     }
     $subject = maia_decode_subject($subject, $document_charset);
     $subject = substr($subject, 0, 255) if length($subject) > 255;
     $subject = untaint($subject);
     $sender = substr($sender, 0, 255) if length($sender) > 255;
+    if ($document_charset ne "") {
+	from_to($contents, $document_charset, "UTF-8");
+    }
 
     if (!$oversized) {
         if ($dbtype =~ /^mysql$/si) { # MySQL


### PR DESCRIPTION
Fairly straight-forward. The regexp for extracting the character set from the Content-Type header was wrong, and where it exists the message content needs to be converted from that character set to UTF-8 before insertion into the database.