### PR TITLE
Fix PHP 8 incompatibility in confirmation of virus code

### DIFF
--- a/php/confirm.php
+++ b/php/confirm.php
@@ -177,7 +177,7 @@
         while ($row = $res->fetchRow())
         {
             $mail_id = $row["id"];
-            delete_mail_reference($euid, $mail_id);
+            delete_mail_reference($euid, array($mail_id));
             $deleted++;
         }
         if ($deleted > 0) {


### PR DESCRIPTION
delete_mail_reference takes an array, not a string, as its second argument.