### PR TITLE
Further fix to parsing of content-type header

### DIFF
--- a/maiad
+++ b/maiad
@@ -3823,8 +3823,8 @@ sub maia_store_mail($$$$$@) {
        if (validate($htype, '^Subject$', 'i')) {
           $subject .= $htext;
        }
-       if (validate($htype, '^Content-Type$', 'i') && validate($htext, 'charset="(.+)"')) {
-          $document_charset = validate($htext, 'charset="(.+)"');
+       if (validate($htype, '^Content-Type$', 'i') && validate($htext, 'charset="([^"]+)"')) {
+          $document_charset = validate($htext, 'charset="([^"]+)"');
        } elsif (validate($htype, '^Content-Type$', 'i') && validate($htext, 'charset=(.+)')) {
           $document_charset = validate($htext, 'charset=(.+)');
        }


### PR DESCRIPTION
The affected header in this case was as follows:

Content-Type: multipart/alternative; charset="UTF-8"; boundary="b1_833e5a867da7187e280aa0590a14bb1a"

This is not particularly sensible, but is permissible in accordance with the RFCs